### PR TITLE
Run `wp-coding-standards/wpcs` to have all code pass linting

### DIFF
--- a/admin/class-neznam-atproto-share-admin.php
+++ b/admin/class-neznam-atproto-share-admin.php
@@ -267,8 +267,8 @@ class Neznam_Atproto_Share_Admin {
 		update_post_meta( $post_id, $this->plugin_name . '-text-to-publish', $text_to_publish );
 
 		if ( get_post_status( $post_id ) === 'publish' ) {
-			$use_cron = get_option( $this->plugin_name . '-use-cron' );
-			$share_info = get_post_meta($post_id, $this->plugin_name . '-uri', true);
+			$use_cron   = get_option( $this->plugin_name . '-use-cron' );
+			$share_info = get_post_meta( $post_id, $this->plugin_name . '-uri', true );
 			if ( ! $use_cron && ! $share_info ) {
 				$logic = new Neznam_Atproto_Share_Logic( $this->plugin_name, $this->version );
 				$logic->post_message( get_post( $post_id ) );
@@ -302,13 +302,13 @@ class Neznam_Atproto_Share_Admin {
 	 */
 	public function render_meta_box() {
 		$uri = get_post_meta( get_the_ID(), $this->plugin_name . '-uri', true );
-		if ($uri) {
-			$uri = explode('/', $uri);
-			$id = array_pop($uri);
-			$handle = get_option($this->plugin_name . '-handle');
+		if ( $uri ) {
+			$uri    = explode( '/', $uri );
+			$id     = array_pop( $uri );
+			$handle = get_option( $this->plugin_name . '-handle' );
 			?>
 			<p><?php esc_html_e( 'Published on Atproto', 'neznam-atproto-share' ); ?></p>
-			<p><a href="<?php echo esc_url('https://bsky.app/profile/' . $handle . '/post/' . $id); ?>" target="_blank" rel="noreferrer"><?php esc_html_e('View on Bluesky', 'neznam-atproto-share'); ?></a></p>
+			<p><a href="<?php echo esc_url( 'https://bsky.app/profile/' . $handle . '/post/' . $id ); ?>" target="_blank" rel="noreferrer"><?php esc_html_e( 'View on Bluesky', 'neznam-atproto-share' ); ?></a></p>
 			<?php
 			return;
 		}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
     "require-dev": {
         "wp-coding-standards/wpcs": "^3.0"
     },
+	"scripts": {
+		"lint": "phpcs",
+		"lint-fix": "phpcbf"
+	},
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/includes/class-neznam-atproto-share-i18n.php
+++ b/includes/class-neznam-atproto-share-i18n.php
@@ -32,7 +32,7 @@ class Neznam_Atproto_Share_I18n {
 		load_plugin_textdomain(
 			'neznam-atproto-share',
 			false,
-			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
+			dirname( plugin_basename( __FILE__ ), 2 ) . '/languages/'
 		);
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for Plugins">
+	<description>Generally-applicable sniffs for WordPress plugins</description>
+
+	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Docs" />
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>


### PR DESCRIPTION
To make sure my future PRs maintain your code standards, I noticed two files were getting flagged by `phpcs`. This PR fixes them, as run by `phpcbf`, and also introduces a `phpcs.xml` from the core WordPress repo so make sure consistent behavior of linting for all plugin devs.