### PR TITLE
Fix issue #4 - `neznam-atproto-share-url` becomes unset

### DIFF
--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -102,6 +102,9 @@ class Neznam_Atproto_Share_Logic {
 		if ( ! $url ) {
 			$url = get_option( $this->plugin_name . '-url' );
 		}
+		if ( empty( $url ) ) {
+			$url = 'https://bsky.social/';
+		}
 		$this->url = $url;
 	}
 


### PR DESCRIPTION
This adds another layer to make sure there isn't a situation where the `wp_remote_post` my happen without a hostname.

Fixes #4 