### PR TITLE
Moves the record->text check from null coalescing to checking for empty

### DIFF
--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -217,7 +217,7 @@ class Neznam_Atproto_Share_Logic {
 			'collection' => 'app.bsky.feed.post',
 			'repo'       => $this->did,
 			'record'     => array(
-				'text'      => $text_to_publish ?? $post->post_title,
+				'text'      => ! empty( $text_to_publish ) ? $text_to_publish : $post->post_title,
 				'createdAt' => gmdate( 'c' ),
 				'embed'     => array(
 					'$type'    => 'app.bsky.embed.external',


### PR DESCRIPTION
Fixes #3 by handling situations where `$text_to_publish` is an empty string, rather than only checking for nullness.