### PR TITLE
Introduce functionality to support multiple post body formats

### DIFF
--- a/admin/class-neznam-atproto-share-admin.php
+++ b/admin/class-neznam-atproto-share-admin.php
@@ -116,6 +116,14 @@ class Neznam_Atproto_Share_Admin {
 		);
 		register_setting(
 			'writing',
+			$this->plugin_name . '-post-format',
+			array(
+				'sanitize_callback' => 'sanitize_text_field',
+				'default'           => 'post_title',
+			)
+		);
+		register_setting(
+			'writing',
 			$this->plugin_name . '-debug-level',
 			array(
 				'sanitize_callback' => 'sanitize_text_field',
@@ -201,6 +209,42 @@ class Neznam_Atproto_Share_Admin {
 				?>
 				<input type="checkbox" name="<?php echo esc_html( $this->plugin_name ); ?>-use-cron" value="1" <?php checked( 1, get_option( $this->plugin_name . '-use-cron' ), true ); ?> />
 				<small><?php esc_html_e( 'Check this if you have trouble publishing posts. This will use cronjob to publish.', 'neznam-atproto-share' ); ?></small>
+				<?php
+			},
+			'writing',
+			$this->plugin_name . '-section'
+		);
+
+		add_settings_field(
+			$this->plugin_name . '-post-format',
+			'Post Format',
+			function () {
+				$cur_format = get_option( $this->plugin_name . '-post-format' );
+				if ( empty( $cur_format ) ) {
+					$cur_format = 'post_title';
+				}
+				$formats = array(
+					'post_title'             => __( 'Post Title', 'neznam-atproto-share ' ),
+					'post_excerpt'           => __( 'Post Excerpt', 'neznam-atproto-share ' ),
+					'post_title_and_excerpt' => __( 'Post Title: Post Excerpt', 'neznam-atproto-share ' ),
+				);
+				?>
+				<select name="<?php echo esc_html( $this->plugin_name ); ?>-post-format">
+				<?php foreach ( $formats as $key => $value ) { ?>
+					<option value="<?php echo esc_html( $key ); ?>"
+												<?php
+												if ( $cur_format === $key ) {
+													echo 'selected="selected"';
+												}
+												?>
+					><?php echo esc_html( $value ); ?></option>
+				<?php } ?>
+				</select>
+				<small>
+				<?php
+				esc_html_e( 'If the "Text to publish" field is blank, this information will populate the post.', 'neznam-atproto-share' );
+				?>
+				</small>
 				<?php
 			},
 			'writing',

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -227,6 +227,18 @@ class Neznam_Atproto_Share_Logic {
 			$blob = $this->upload_blob( $image_path );
 		}
 		$text_to_publish = get_post_meta( get_the_ID(), $this->plugin_name . '-text-to-publish', true );
+		if ( ! empty( $text_to_publish ) ) {
+			$post_text = $text_to_publish;
+		} else {
+			$post_format = get_option( $this->plugin_name . '-post-format' );
+			if ( 'post_excerpt' === $post_format ) {
+				$post_text = $post->post_excerpt;
+			} elseif ( 'post_title_and_excerpt' === $post_format ) {
+				$post_text = $post->post_title . ': ' . $post->post_excerpt;
+			} else {
+				$post_text = $post->post_title;
+			}
+		}
 
 		$locale = str_replace( '_', '-', get_locale() );
 
@@ -234,7 +246,7 @@ class Neznam_Atproto_Share_Logic {
 			'collection' => 'app.bsky.feed.post',
 			'repo'       => $this->did,
 			'record'     => array(
-				'text'      => ! empty( $text_to_publish ) ? $text_to_publish : $post->post_title,
+				'text'      => $post_text,
 				'createdAt' => gmdate( 'c' ),
 				'embed'     => array(
 					'$type'    => 'app.bsky.embed.external',

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -231,9 +231,9 @@ class Neznam_Atproto_Share_Logic {
 			$post_text = $text_to_publish;
 		} else {
 			$post_format = get_option( $this->plugin_name . '-post-format' );
-			if ( 'post_excerpt' === $post_format ) {
+			if ( ! empty( $post->post_excerpt ) && 'post_excerpt' === $post_format ) {
 				$post_text = $post->post_excerpt;
-			} elseif ( 'post_title_and_excerpt' === $post_format ) {
+			} elseif ( ! empty( $post->post_excerpt ) && 'post_title_and_excerpt' === $post_format ) {
 				$post_text = $post->post_title . ': ' . $post->post_excerpt;
 			} else {
 				$post_text = $post->post_title;

--- a/uninstall.php
+++ b/uninstall.php
@@ -39,3 +39,4 @@ delete_option( $plugin_name . '-access-token' );
 delete_option( $plugin_name . '-refresh-token' );
 delete_option( $plugin_name . '-use-cron' );
 delete_option( $plugin_name . '-debug-level' );
+delete_option( $plugin_name . '-post-format' );


### PR DESCRIPTION
Based on #12, this adds a section in the admin area that controls the post's text if "Text to publish" is blank:
* `post_title` <- This is the default, and fallback if `$post->post_excerpt` is blank
* `post_excerpt` <- If `$post->post_excerpt` is not blank, posts this
* `post_title_and_excerpt` <- If `$post->post_excerpt` is not blank, posts in the format of `Title: Excerpt`