### PR TITLE
"Comments Overview" view, feed sanitization, and lazy loading

### DIFF
--- a/admin/class-neznam-atproto-share-admin.php
+++ b/admin/class-neznam-atproto-share-admin.php
@@ -59,7 +59,7 @@ class Neznam_Atproto_Share_Admin {
 	 */
 	public function settings_link( $links ) {
 		// Build and escape the URL.
-		$url = esc_url( add_query_arg( 'page', $this->plugin_name, get_admin_url(null, 'options-general.php') ) );
+		$url = esc_url( add_query_arg( 'page', $this->plugin_name, get_admin_url( null, 'options-general.php' ) ) );
 		// Create the link.
 		$settings_link = "<a href='$url'>" . __( 'Settings', 'neznam-atproto-share' ) . '</a>';
 		// Adds the link to the end of the array.
@@ -70,18 +70,28 @@ class Neznam_Atproto_Share_Admin {
 		return $links;
 	}
 
+	/**
+	 * Injects the "ATProto Share" link into the options submenu.
+	 *
+	 * @since 2.0.0
+	 */
 	public function add_page() {
-		add_options_page('ATProto Share', 'ATProto Share', 'manage_options', 'neznam-atproto-share', array($this, 'create_admin_page'));
+		add_options_page( 'ATProto Share', 'ATProto Share', 'manage_options', 'neznam-atproto-share', array( $this, 'create_admin_page' ) );
 	}
 
+	/**
+	 * Generates the options submenu page.
+	 *
+	 * @since 2.0.0
+	 */
 	public function create_admin_page() {
 		?>
 		<div class="wrap">
 			<h2>ATProto Share Settings</h2>
 			<form method="post" action="options.php">
 				<?php
-				settings_fields('neznam-atproto-share');
-				do_settings_sections('neznam-atproto-share');
+				settings_fields( 'neznam-atproto-share' );
+				do_settings_sections( 'neznam-atproto-share' );
 				submit_button();
 				?>
 			</form>
@@ -346,8 +356,8 @@ class Neznam_Atproto_Share_Admin {
 			'Comments settings',
 			function () {
 				echo '<p>' .
-					 esc_html__( 'Enable comments.', 'neznam-atproto-share' ) .
-					 '</p>';
+					esc_html__( 'Enable comments.', 'neznam-atproto-share' ) .
+					'</p>';
 			},
 			'neznam-atproto-share',
 		);
@@ -549,7 +559,7 @@ class Neznam_Atproto_Share_Admin {
 	 */
 	public function render_meta_box() {
 		$url = get_post_meta( get_the_ID(), $this->plugin_name . '-http-uri', true );
-		if (!$url) {
+		if ( ! $url ) {
 			$uri = get_post_meta( get_the_ID(), $this->plugin_name . '-uri', true );
 			if ( $uri ) {
 				$uri    = explode( '/', $uri );

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -288,11 +288,11 @@ class Neznam_Atproto_Share_Logic {
 		$body          = json_decode( $response_body, true );
 		if ( isset( $body['uri'] ) && $this->validate_at_uri( $body['uri'] ) ) {
 			update_post_meta( $post->ID, $this->plugin_name . '-uri', $body['uri'] );
-			$uri    = explode( '/', $body['uri'] );
-			$id     = array_pop( $uri );
+			$uri = explode( '/', $body['uri'] );
+			$id  = array_pop( $uri );
 			// TODO: when other networks are added, this will need to be updated.
 			$url = 'https://bsky.app/profile/' . $this->handle . '/post/' . $id;
-			update_post_meta( $post->ID, $this->plugin_name . '-http-uri',  $url);
+			update_post_meta( $post->ID, $this->plugin_name . '-http-uri', $url );
 			$this->log( 'DEBUG', 'Record successfully created. URI is ' . esc_html( $body['uri'] ) );
 		} else {
 			$this->log( 'ERROR', 'Failed to create record. Response from server: ' . esc_html( $response_body ) );

--- a/public/css/neznam-atproto-share-comments.css
+++ b/public/css/neznam-atproto-share-comments.css
@@ -2,6 +2,10 @@
     list-style: none;
 }
 
+#comments.neznam-atproto-share-comments ol.comment-list {
+    padding-inline-start: 0;
+}
+
 #comments.neznam-atproto-share-comments ol article {
     display: flex;
     gap: 5px;
@@ -39,14 +43,14 @@
 #comments.neznam-atproto-share-comments ol .comment-metadata time {
     margin: 0;
 }
-#comments.neznam-atproto-share-comments ol article a {
+#comments.neznam-atproto-share-comments a {
     text-decoration: none;
 }  
-#comments.neznam-atproto-share-comments ol article a:hover, #comments.neznam-atproto-share-comments ol article a:active {
+#comments.neznam-atproto-share-comments a:hover, #comments.neznam-atproto-share-comments a:active {
     text-decoration: underline;
 }  
 
-#comments.neznam-atproto-share-comments ol article .comment-reply-link, #comments.neznam-atproto-share-comments ol article .comment-repost-link, #comments.neznam-atproto-share-comments ol article .comment-like-link {
+#comments.neznam-atproto-share-comments .comment-reply-link, #comments.neznam-atproto-share-comments .comment-repost-link, #comments.neznam-atproto-share-comments .comment-like-link, #comments.neznam-atproto-share-comments .comment-quote-link {
     display: inline-block;
     background-position: left 0 top 0;
     background-repeat: no-repeat;
@@ -56,12 +60,15 @@
     border: 0;
     font-weight: normal;
 }
-#comments.neznam-atproto-share-comments ol article .comment-reply-link {
+#comments.neznam-atproto-share-comments .comment-reply-link {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21" style="stroke:currentColor"><path fill="none" stroke-linecap="round" stroke-linejoin="round" d="M11 16.517c4.418 0 8-3.284 8-7.017S15.418 3 11 3S3 6.026 3 9.759c0 1.457.546 2.807 1.475 3.91L3.5 18.25l3.916-2.447a9.2 9.2 0 0 0 3.584.714" /></svg>');
 }
-#comments.neznam-atproto-share-comments ol article .comment-repost-link {
+#comments.neznam-atproto-share-comments .comment-repost-link {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21" style="stroke:currentColor"><g fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round"><path d="m13.5 13.5l3 3l3-3" /><path d="M9.5 4.5h3a4 4 0 0 1 4 4v8m-9-9l-3-3l-3 3" /><path d="M11.5 16.5h-3a4 4 0 0 1-4-4v-8" /></g></svg>');
 }
-#comments.neznam-atproto-share-comments ol article .comment-like-link {
+#comments.neznam-atproto-share-comments .comment-like-link {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21" style="stroke:currentColor"><path fill="none" stroke-linecap="round" stroke-linejoin="round" d="M10.5 6.5c.5-2.5 4.343-2.657 6-1c1.603 1.603 1.5 4.334 0 6l-6 6l-6-6a4.243 4.243 0 0 1 0-6c1.55-1.55 5.5-1.5 6 1" /></svg>');
+}
+#comments.neznam-atproto-share-comments .comment-quote-link {
+    background-image: url('data:image/svg+xml;utf8,<svg height="21" viewBox="0 0 21 21" width="21" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" transform="translate(4 3)"><path d="m12.5 12.5v-10c0-1.1045695-.8954305-2-2-2h-8c-1.1045695 0-2 .8954305-2 2v10c0 1.1045695.8954305 2 2 2h8c1.1045695 0 2-.8954305 2-2z"/><path d="m3.5 5.5h5"/><path d="m3.5 7.5h6"/><path d="m3.5 9.5h3"/></g></svg>');
 }

--- a/public/partials/comments.php
+++ b/public/partials/comments.php
@@ -58,11 +58,36 @@ $comment_template = '<article class="comment comment-body">
       </article>';
 $comment_template = apply_filters( 'neznam_atproto_comment_template', $comment_template );
 
+$comment_overview = '<div class="comment-overview">
+		<a class="comment-reply-link" href="##POST_URL##" rel="ugc external nofollow" target="_blank">
+			##TOTAL_REPLIES##
+		</a>
+		<span>&nbsp;&nbsp;</span>
+
+		<a class="comment-repost-link" href="##POST_URL##" rel="ugc external nofollow" target="_blank">
+			##TOTAL_REPOSTS##
+		</a>
+		<span>&nbsp;&nbsp;</span>
+
+		<a class="comment-like-link" href="##POST_URL##" rel="ugc external nofollow" target="_blank">
+			##TOTAL_LIKES##
+		</a>
+		<span>&nbsp;&nbsp;</span>
+
+		<a class="comment-quote-link" href="##POST_URL##" rel="ugc external nofollow" target="_blank">
+			##TOTAL_QUOTES##
+		</a>
+	  </div>';
+$comment_overview = apply_filters( 'neznam_atproto_comment_overview', $comment_overview );
+
 $allowed_html         = wp_kses_allowed_html( 'post' );
 $allowed_html['time'] = array( 'datetime' => true );
 
 echo '<script type="text/html" id="neznam-atproto-comment-template">';
 echo wp_kses( $comment_template, $allowed_html );
+echo '</script>';
+echo '<script type="text/html" id="neznam-atproto-comment-overview">';
+echo wp_kses( $comment_overview, $allowed_html );
 echo '</script>';
 $direct_link = 'https://bsky.app/profile/' . esc_attr( $handle ) . '/post/' . esc_attr( substr( $bluesky_uri, strrpos( $bluesky_uri, '/' ) + 1 ) );
 echo '<div id="comments" class="comments-area neznam-atproto-share-comments" data-uri="' . esc_attr( $bluesky_uri ) . '">


### PR DESCRIPTION
## Adds a basic comment overview header, to indicate overall thread popularity
![image](https://github.com/user-attachments/assets/9d8e5da1-061a-4886-81d2-181b4a47b0a2)

This introduces the `neznam_atproto_comment_overview` filter, with these 4 variables:
* `##TOTAL_REPLIES##`
* `##TOTAL_REPOSTS##`
* `##TOTAL_LIKES##`
* `##TOTAL_QUOTES##` <- This is intentionally only at the top-level, because quoting thread replies doesn't seem common.

## Performs some client-side attribute and HTML escaping, to make sure no characters become a part of the dom
![image](https://github.com/user-attachments/assets/b0b69444-ed72-4673-9a73-49bd3b01913c)

Also adding `loading="lazy"` to profile images to be nicer to Bluesky's server on long threads, and ran the scripts through linting.