### PR TITLE
AJAX metabox, disassociating posts, linking posts, paginated comments, rich comments, uploads via local path

### DIFF
--- a/admin/class-neznam-atproto-share-admin-metabox.php
+++ b/admin/class-neznam-atproto-share-admin-metabox.php
@@ -1,0 +1,306 @@
+<?php
+/**
+ * Admin Metabox class
+ *
+ * @package   Neznam_Atproto_Share
+ * @subpackage Neznam_Atproto_Share/admin
+ * @link      https://www.neznam.hr
+ * @since      2.1.0
+ */
+
+/**
+ * The metabox-related functionality of the admin area.
+ *
+ * @package    Neznam_Atproto_Share
+ * @subpackage Neznam_Atproto_Share/admin
+ * @author     Marko Banušić <mbanusic@gmail.com>
+ */
+class Neznam_Atproto_Share_Admin_Metabox {
+
+	/**
+	 * The ID of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string $plugin_name The ID of this plugin.
+	 */
+	private $plugin_name;
+
+	/**
+	 * The version of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string $version The current version of this plugin.
+	 */
+	private $version;
+
+	/**
+	 * The Neznam_Atproto_Share_Logic object.
+	 *
+	 * @since    2.1.0
+	 * @access   private
+	 * @var      \Neznam_Atproto_Share_Logic $plugin_share The object for shared logic.
+	 */
+	private $plugin_share;
+
+	/**
+	 * The Neznam_Atproto_Share_Admin object.
+	 *
+	 * @since    2.1.0
+	 * @access   private
+	 * @var      \Neznam_Atproto_Share_Admin $plugin_admin The object for admin functionality.
+	 */
+	private $plugin_admin;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @param string $plugin_name The name of this plugin.
+	 * @param string $version The version of this plugin.
+	 * @param object $plugin_share The Neznam_Atproto_Share_Logic object.
+	 * @param object $plugin_admin The Neznam_Atproto_Share_Admin object.
+	 *
+	 * @since    1.0.0
+	 */
+	public function __construct( $plugin_name, $version, $plugin_share, $plugin_admin ) {
+
+		$this->plugin_name  = $plugin_name;
+		$this->version      = $version;
+		$this->plugin_share = $plugin_share;
+		$this->plugin_admin = $plugin_admin;
+	}
+
+	/**
+	 * Add meta box to post
+	 *
+	 * @return void
+	 */
+	public function add_meta_box() {
+		add_meta_box(
+			$this->plugin_name . '-meta-box',
+			__( 'Atproto Share', 'neznam-atproto-share' ),
+			array(
+				$this,
+				'render_meta_box',
+			),
+			'post',
+			'side',
+			'high',
+		);
+	}
+
+	/**
+	 * Injects the scripts needed by the meta box.
+	 *
+	 * @return null
+	 * @since 2.1.0
+	 */
+	public function meta_box_scripts() {
+		$screen = get_current_screen();
+		if ( ! is_object( $screen ) || 'post' !== $screen->post_type ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			$this->plugin_name . '-meta-box-script',
+			plugin_dir_url( __FILE__ ) . 'meta-boxes/js/admin.js',
+			array( 'jquery' ),
+			$this->version,
+			array(
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			)
+		);
+
+		wp_localize_script(
+			$this->plugin_name . '-meta-box-script',
+			str_replace( '-', '_', $this->plugin_name ) . '_meta_box_object',
+			$this->get_ajax_data()
+		);
+	}
+
+	/**
+	 * Render meta box
+	 *
+	 * @return void
+	 */
+	public function render_meta_box() {
+		?>
+		<p id="<?php echo esc_html( $this->plugin_name ); ?>-message" class="error-message style="display: none"></p>
+		<div id="<?php echo esc_html( $this->plugin_name ); ?>-published-post" style="display: none">
+			<p><?php esc_html_e( 'Published on Atproto', 'neznam-atproto-share' ); ?></p>
+			<p><a href="#" class="ext-link" target="_blank" rel="noreferrer"><?php esc_html_e( 'View on Bluesky', 'neznam-atproto-share' ); ?></a></p>
+			<hr>
+			<p class="howto"><?php esc_html_e( 'Disassociate this entry with the published Atproto post.', 'neznam-atproto-share' ); ?></p>
+			<button type="button" class="update">Disassociate Post</button>
+			<span class="spinner"></span>
+		</div>
+		<div id="<?php echo esc_html( $this->plugin_name ); ?>-publish-post" style="display: none">
+			<input
+				id="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"
+				name="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"
+				type="checkbox"
+				value="1">
+			<label
+				for="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"><?php esc_html_e( 'Publish on Atproto?', 'neznam-atproto-share' ); ?></label>
+			<p class="howto"><?php esc_html_e( 'Publishes post to Atproto network.', 'neznam-atproto-share' ); ?></p>
+			<label
+				for="<?php echo esc_html( $this->plugin_name ); ?>-text-to-publish"><?php esc_html_e( 'Text to publish', 'neznam-atproto-share' ); ?></label>
+			<input
+				id="<?php echo esc_html( $this->plugin_name ); ?>-text-to-publish"
+				name="<?php echo esc_html( $this->plugin_name ); ?>-text-to-publish"
+				type="text"
+				value=""/>
+			<p class="howto"><?php esc_html_e( 'Text to add as status', 'neznam-atproto-share' ); ?></p>
+			<button type="button" class="update">Update</button>
+			<span class="spinner"></span>
+			<hr>
+			<a href="#" id="<?php echo esc_html( $this->plugin_name ); ?>-switch-link-post" data-mode="link" style="display:none"><small><?php esc_html_e( 'Already posted on network? Link to the post.', 'neznam-atproto-share' ); ?></small></a>
+		</div>
+		<div id="<?php echo esc_html( $this->plugin_name ); ?>-link-post" style="display: none">
+			<label
+				for="<?php echo esc_html( $this->plugin_name ); ?>-published-rkey"><?php esc_html_e( 'Record key of published post', 'neznam-atproto-share' ); ?></label>
+			<input
+				id="<?php echo esc_html( $this->plugin_name ); ?>-published-rkey"
+				name="<?php echo esc_html( $this->plugin_name ); ?>-published-rkey"
+				type="text">
+			<p class="howto"><?php esc_html_e( 'Record key of the post. Typically a 13-character string after post/ in the URI.', 'neznam-atproto-share' ); ?></p>
+			<button type="button" class="update">Update</button>
+			<span class="spinner"></span>
+			<hr>
+			<p><a href="#" id="<?php echo esc_html( $this->plugin_name ); ?>-switch-publish-post" data-mode="publish"><small><?php esc_html_e( 'Switch back to publish post.', 'neznam-atproto-share' ); ?></small></a></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Handles the various AJAX actions requested by the meta box
+	 *
+	 * @since 2.1.0
+	 */
+	public function ajax_handler() {
+		if ( ! check_ajax_referer( $this->plugin_name . 'update-post-nonce', 'nonce', false ) ) {
+			wp_send_json_error(
+				array(
+					'error' => esc_html__( 'Invalid security token sent.', 'neznam-atproto-share' ),
+				)
+			);
+		}
+
+		$post_id = isset( $_POST['post_id'] ) ? sanitize_text_field( wp_unslash( $_POST['post_id'] ) ) : '';
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			wp_send_json_error(
+				array(
+					'error' => esc_html__( 'Permission denied to edit post.', 'neznam-atproto-share' ),
+				)
+			);
+		}
+
+		$subaction = isset( $_POST['subaction'] ) ? sanitize_text_field( wp_unslash( $_POST['subaction'] ) ) : '';
+		if ( 'disassociate' === $subaction ) {
+			delete_post_meta( $post_id, $this->plugin_name . '-uri' );
+			delete_post_meta( $post_id, $this->plugin_name . '-http-uri' );
+			wp_send_json_success( $this->get_ajax_data( $post_id ) );
+		} elseif ( 'publish' === $subaction ) {
+			$should_publish  = ! empty( $_POST['publish'] ) ? 1 : 0;
+			$text_to_publish = isset( $_POST['text'] ) ? sanitize_text_field( wp_unslash( $_POST['text'] ) ) : '';
+			update_post_meta( $post_id, $this->plugin_name . '-should-publish', $should_publish );
+			update_post_meta( $post_id, $this->plugin_name . '-text-to-publish', $text_to_publish );
+			if ( 'publish' === get_post_status( $post_id ) ) {
+				$this->plugin_admin->publish_post( $post_id, get_post( $post_id ) );
+			}
+			$share_info = get_post_meta( $post_id, $this->plugin_name . '-uri', true );
+			if ( ! empty( $share_info ) ) {
+				wp_send_json_success( $this->get_ajax_data( $post_id ) );
+			} else {
+				wp_send_json_error(
+					array(
+						'error' => esc_html__( 'Failed to publish new post.', 'neznam-atproto-share' ),
+					)
+				);
+			}
+		} elseif ( 'link' === $subaction ) {
+			$rkey = isset( $_POST['rkey'] ) ? sanitize_text_field( wp_unslash( $_POST['rkey'] ) ) : '';
+			if ( $this->link_post( $post_id, $rkey ) ) {
+				wp_send_json_success( $this->get_ajax_data( $post_id ) );
+			} else {
+				wp_send_json_error(
+					array(
+						'error' => esc_html__( 'Failed to link to existing post.', 'neznam-atproto-share' ),
+					)
+				);
+			}
+		} else {
+			wp_send_json_error(
+				array(
+					'error' => esc_html__( 'Unrecognized AJAX action attempted.', 'neznam-atproto-share' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Attempts to link the blog's post to the AtProto post
+	 *
+	 * @param string $post_id The post's ID.
+	 * @param string $rkey Record key of the AtProto post.
+	 *
+	 * @return bool
+	 * @since 2.1.0
+	 */
+	private function link_post( $post_id, $rkey ) {
+		$record = $this->plugin_share->record_request( $rkey );
+		if ( ! empty( $record['uri'] ) ) {
+			update_post_meta( $post_id, $this->plugin_name . '-uri', $record['uri'] );
+			$handle   = get_option( $this->plugin_name . '-handle' );
+			$http_uri = 'https://bsky.app/profile/' . $handle . '/post/' . $rkey;
+			update_post_meta( $post_id, $this->plugin_name . '-http-uri', $http_uri );
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Generates the data used to render the meta box.
+	 *
+	 * @param mixed $post_id The post's ID, defaults to result of `get_the_ID`.
+	 *
+	 * @return array
+	 * @since 2.1.0
+	 */
+	private function get_ajax_data( $post_id = false ) {
+		if ( false === $post_id ) {
+			$post_id = get_the_ID();
+		}
+		$url = get_post_meta( $post_id, $this->plugin_name . '-http-uri', true );
+		if ( ! $url ) {
+			$uri = get_post_meta( $post_id, $this->plugin_name . '-uri', true );
+			if ( $uri ) {
+				$uri    = explode( '/', $uri );
+				$id     = array_pop( $uri );
+				$handle = get_option( $this->plugin_name . '-handle' );
+				$url    = 'https://bsky.app/profile/' . $handle . '/post/' . $id;
+				update_post_meta( $post_id, $this->plugin_name . '-http-uri', $url );
+			}
+		}
+
+		$should_publish = get_post_meta( $post_id, $this->plugin_name . '-should-publish', true );
+
+		if ( false === $should_publish || '' === $should_publish ) {
+			$should_publish = get_option( $this->plugin_name . '-default' );
+		}
+		$published       = get_post_status( $post_id ) === 'publish';
+		$text_to_publish = get_post_meta( $post_id, $this->plugin_name . '-text-to-publish', true );
+		return array(
+			'url'             => admin_url( 'admin-ajax.php' ),
+			'nonce'           => wp_create_nonce( $this->plugin_name . 'update-post-nonce' ),
+			'published'       => $published,
+			'text_to_publish' => $text_to_publish,
+			'should_publish'  => $should_publish,
+			'atproto_url'     => $url,
+		);
+	}
+}

--- a/admin/class-neznam-atproto-share-admin.php
+++ b/admin/class-neznam-atproto-share-admin.php
@@ -36,17 +36,38 @@ class Neznam_Atproto_Share_Admin {
 	private $version;
 
 	/**
+	 * The Neznam_Atproto_Share_Logic object.
+	 *
+	 * @since    2.1.0
+	 * @access   private
+	 * @var      \Neznam_Atproto_Share_Logic $plugin_share The object for shared logic.
+	 */
+	private $plugin_share;
+
+	/**
+	 * The Neznam_Atproto_Share_Admin_Metabox object.
+	 *
+	 * @since    2.1.0
+	 * @access   private
+	 * @var      \Neznam_Atproto_Share_Admin_Metabox $plugin_share The object for metabox-related functions.
+	 */
+	private $plugin_metabox;
+
+	/**
 	 * Initialize the class and set its properties.
 	 *
 	 * @param string $plugin_name The name of this plugin.
 	 * @param string $version The version of this plugin.
+	 * @param object $plugin_share The Neznam_Atproto_Share_Logic object.
 	 *
 	 * @since    1.0.0
 	 */
-	public function __construct( $plugin_name, $version ) {
+	public function __construct( $plugin_name, $version, $plugin_share ) {
 
-		$this->plugin_name = $plugin_name;
-		$this->version     = $version;
+		$this->plugin_name    = $plugin_name;
+		$this->version        = $version;
+		$this->plugin_share   = $plugin_share;
+		$this->plugin_metabox = new Neznam_Atproto_Share_Admin_Metabox( $this->plugin_name, $this->version, $this->plugin_share, $this );
 	}
 
 	/**
@@ -100,11 +121,17 @@ class Neznam_Atproto_Share_Admin {
 	}
 
 	/**
-	 * Add all settings
+	 * Add all settings and attach metabox management.
 	 *
 	 * @since    1.0.0
 	 */
-	public function add_settings() {
+	public function admin_init() {
+		if ( get_option( $this->plugin_name . '-did' ) ) {
+			add_action( 'admin_enqueue_scripts', array( $this->plugin_metabox, 'meta_box_scripts' ) );
+			add_action( 'add_meta_boxes', array( $this->plugin_metabox, 'add_meta_box' ) );
+			add_action( 'wp_ajax_' . $this->plugin_name, array( $this->plugin_metabox, 'ajax_handler' ) );
+		}
+
 		register_setting(
 			'neznam-atproto-share',
 			$this->plugin_name . '-url',
@@ -203,7 +230,7 @@ class Neznam_Atproto_Share_Admin {
 
 		add_settings_field(
 			$this->plugin_name . '-url',
-			'Atproto URL',
+			'ATProto URL',
 			function () {
 				?>
 				<input type="text" name="<?php echo esc_html( $this->plugin_name ); ?>-url" value="<?php echo esc_html( get_option( $this->plugin_name . '-url' ) ); ?>" /><br>
@@ -414,7 +441,7 @@ class Neznam_Atproto_Share_Admin {
 		$logic->set_url( sanitize_url( wp_unslash( $_POST[ $this->plugin_name . '-url' ] ) ) );
 		$logic->set_handle( $handle );
 		if ( ! $logic->did_request() ) {
-			add_settings_error( $this->plugin_name . '-handle', 'handle', __( 'Handle is incorrect', 'neznam-atproto-share' ) );
+			add_settings_error( $this->plugin_name . '-handle', 'handle', __( 'Handle is incorrect - ', 'neznam-atproto-share' ) . esc_html( $handle ) );
 		}
 		return $handle;
 	}
@@ -478,33 +505,6 @@ class Neznam_Atproto_Share_Admin {
 	/**
 	 * On save post save the information for reposting on atproto.
 	 *
-	 * @param int $post_id Post ID.
-	 *
-	 * @return void
-	 */
-	public function edit_post( $post_id ) {
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( ! isset( $_POST[ $this->plugin_name . 'should-publish-nonce' ] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST[ $this->plugin_name . 'should-publish-nonce' ] ) ), 'save-should-publish' ) ) {
-			return;
-		}
-
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-
-		$should_publish  = isset( $_POST[ $this->plugin_name . '-should-publish' ] ) ? 1 : 0;
-		$text_to_publish = isset( $_POST[ $this->plugin_name . '-text-to-publish' ] ) ? sanitize_text_field( wp_unslash( $_POST[ $this->plugin_name . '-text-to-publish' ] ) ) : '';
-
-		update_post_meta( $post_id, $this->plugin_name . '-should-publish', $should_publish );
-		update_post_meta( $post_id, $this->plugin_name . '-text-to-publish', $text_to_publish );
-	}
-
-	/**
-	 * On save post save the information for reposting on atproto.
-	 *
 	 * @param int     $post_id Post ID.
 	 * @param WP_Post $post The Post itself.
 	 *
@@ -531,75 +531,6 @@ class Neznam_Atproto_Share_Admin {
 			$logic = new Neznam_Atproto_Share_Logic( $this->plugin_name, $this->version );
 			$logic->post_message( $post );
 		}
-	}
-
-	/**
-	 * Add meta box to post
-	 *
-	 * @return void
-	 */
-	public function add_meta_box() {
-		add_meta_box(
-			$this->plugin_name . '-meta-box',
-			__( 'Atproto Share', 'neznam-atproto-share' ),
-			array(
-				$this,
-				'render_meta_box',
-			),
-			'post',
-			'side',
-			'high',
-		);
-	}
-
-	/**
-	 * Render meta box
-	 *
-	 * @return void
-	 */
-	public function render_meta_box() {
-		$url = get_post_meta( get_the_ID(), $this->plugin_name . '-http-uri', true );
-		if ( ! $url ) {
-			$uri = get_post_meta( get_the_ID(), $this->plugin_name . '-uri', true );
-			if ( $uri ) {
-				$uri    = explode( '/', $uri );
-				$id     = array_pop( $uri );
-				$handle = get_option( $this->plugin_name . '-handle' );
-				$url    = 'https://bsky.app/profile/' . $handle . '/post/' . $id;
-			}
-		}
-		if ( $url ) {
-			?>
-			<p><?php esc_html_e( 'Published on Atproto', 'neznam-atproto-share' ); ?></p>
-			<p><a href="<?php echo esc_url( $url ); ?>" target="_blank" rel="noreferrer"><?php esc_html_e( 'View on Bluesky', 'neznam-atproto-share' ); ?></a></p>
-			<?php
-			return;
-		}
-		$should_publish = get_post_meta( get_the_ID(), $this->plugin_name . '-should-publish', true );
-
-		if ( false === $should_publish || '' === $should_publish ) {
-			$should_publish = get_option( $this->plugin_name . '-default' );
-		}
-		$text_to_publish = get_post_meta( get_the_ID(), $this->plugin_name . '-text-to-publish', true );
-		?>
-		<input
-			id="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"
-			name="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"
-			type="checkbox"
-			value="1" <?php checked( $should_publish ); ?>>
-		<label
-			for="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"><?php esc_html_e( 'Publish on Atproto?', 'neznam-atproto-share' ); ?></label>
-		<p class="howto"><?php esc_html_e( 'Publishes post to Atproto network.', 'neznam-atproto-share' ); ?></p>
-		<label
-			for="<?php echo esc_html( $this->plugin_name ); ?>-text-to-publish"><?php esc_html_e( 'Text to publish', 'neznam-atproto-share' ); ?></label>
-		<input
-			id="<?php echo esc_html( $this->plugin_name ); ?>-text-to-publish"
-			name="<?php echo esc_html( $this->plugin_name ); ?>-text-to-publish"
-			type="text"
-			value="<?php echo esc_html( $text_to_publish ); ?>"/>
-		<p class="howto"><?php esc_html_e( 'Text to add as status', 'neznam-atproto-share' ); ?></p>
-		<?php wp_nonce_field( 'save-should-publish', $this->plugin_name . 'should-publish-nonce' ); ?>
-		<?php
 	}
 
 	/**

--- a/admin/class-neznam-atproto-share-admin.php
+++ b/admin/class-neznam-atproto-share-admin.php
@@ -527,7 +527,7 @@ class Neznam_Atproto_Share_Admin {
 
 		$should_publish = get_post_meta( $post_id, $this->plugin_name . '-should-publish', true );
 
-		if ( $should_publish ) {
+		if ( $should_publish && '0' !== $should_publish ) {
 			$logic = new Neznam_Atproto_Share_Logic( $this->plugin_name, $this->version );
 			$logic->post_message( $post );
 		}

--- a/admin/meta-boxes/js/admin.js
+++ b/admin/meta-boxes/js/admin.js
@@ -1,0 +1,111 @@
+/* global jQuery */
+(function ($, window, document) {
+  'use strict'
+  const pluginName = 'neznam-atproto-share'
+  $(document).ready(function () {
+    $(`#${pluginName}-switch-link-post, #${pluginName}-switch-publish-post`).on('click', function (e) {
+      e.preventDefault()
+      $(`#${pluginName}-publish-mode`).val($(this).data('mode'))
+      $(`#${pluginName}-publish-post, #${pluginName}-link-post`).toggle()
+    })
+
+    let boxData = neznam_atproto_share_meta_box_object // eslint-disable-line
+    const $publishedBox = $(`#${pluginName}-published-post`)
+    const $publishBox = $(`#${pluginName}-publish-post`)
+    const $linkBox = $(`#${pluginName}-link-post`)
+
+    const processUI = function () {
+      $publishedBox.hide()
+      $publishBox.hide()
+      $linkBox.hide()
+
+      if (boxData.atproto_url) {
+        $publishedBox.show()
+        $publishedBox.find('a.ext-link').attr('href', boxData.atproto_url)
+        return
+      }
+      $(`#${pluginName}-text-to-publish`).val(boxData.text_to_publish)
+      if (boxData.should_publish) {
+        $(`#${pluginName}-should-publish`).prop('checked', true)
+      }
+      $(`#${pluginName}-should-publish`).prop('checked', true)
+      $(`#${pluginName}-publish-post`).show()
+      if (boxData.published) {
+        $(`#${pluginName}-switch-link-post`).show()
+      }
+    }
+    processUI()
+    $publishedBox.find('.update').on('click', function () {
+      const $update = $(this)
+      $update.prop('disabled', true)
+      $publishedBox.find('.spinner').addClass('is-active')
+      $.post(boxData.url,
+        {
+          action: pluginName,
+          post_id: jQuery('#post_ID').val(),
+          nonce: boxData.nonce,
+          subaction: 'disassociate'
+        }, function (response) {
+          $update.prop('disabled', false)
+          $publishedBox.find('.spinner').removeClass('is-active')
+          if (!response.success) {
+            $(`#${pluginName}-message`).text(response.data.error).show()
+            return
+          }
+          $(`#${pluginName}-message`).hide()
+          boxData = response.data
+          processUI()
+        }
+      )
+    })
+    $publishBox.find('.update').on('click', function () {
+      const $update = $(this)
+      $update.prop('disabled', true)
+      $publishBox.find('.spinner').addClass('is-active')
+      $.post(boxData.url,
+        {
+          action: pluginName,
+          post_id: jQuery('#post_ID').val(),
+          nonce: boxData.nonce,
+          subaction: 'publish',
+          publish: $(`#${pluginName}-should-publish`).is(':checked'),
+          text: $(`#${pluginName}-text-to-publish`).val()
+        }, function (response) {
+          $update.prop('disabled', false)
+          $publishBox.find('.spinner').removeClass('is-active')
+          if (!response.success) {
+            $(`#${pluginName}-message`).text(response.data.error).show()
+            return
+          }
+          $(`#${pluginName}-message`).hide()
+          boxData = response.data
+          processUI()
+        }
+      )
+    })
+    $linkBox.find('.update').on('click', function () {
+      const $update = $(this)
+      $update.prop('disabled', true)
+      $linkBox.find('.spinner').addClass('is-active')
+      $.post(boxData.url,
+        {
+          action: pluginName,
+          post_id: jQuery('#post_ID').val(),
+          nonce: boxData.nonce,
+          subaction: 'link',
+          rkey: $(`#${pluginName}-published-rkey`).val()
+        }, function (response) {
+          $update.prop('disabled', false)
+          $linkBox.find('.spinner').removeClass('is-active')
+          if (!response.success) {
+            $(`#${pluginName}-message`).text(response.data.error).show()
+            return
+          }
+          $(`#${pluginName}-message`).hide()
+          boxData = response.data
+          processUI()
+        }
+      )
+    })
+  })
+}(jQuery, window, document))

--- a/admin/meta-boxes/js/admin.js
+++ b/admin/meta-boxes/js/admin.js
@@ -25,16 +25,16 @@
         return
       }
       $(`#${pluginName}-text-to-publish`).val(boxData.text_to_publish)
-      if (boxData.should_publish) {
+      if (boxData.should_publish && boxData.should_publish !== '0') {
         $(`#${pluginName}-should-publish`).prop('checked', true)
       }
-      $(`#${pluginName}-should-publish`).prop('checked', true)
       $(`#${pluginName}-publish-post`).show()
       if (boxData.published) {
         $(`#${pluginName}-switch-link-post`).show()
       }
     }
     processUI()
+
     $publishedBox.find('.update').on('click', function () {
       const $update = $(this)
       $update.prop('disabled', true)
@@ -58,6 +58,15 @@
         }
       )
     })
+
+    $(`#${pluginName}-text-to-publish`).on('blur', function () {
+      $publishBox.find('.update').data('skip-post', true)
+      $publishBox.find('.update').trigger('click')
+    })
+    $(`#${pluginName}-should-publish`).on('change', function () {
+      $publishBox.find('.update').data('skip-post', true)
+      $publishBox.find('.update').trigger('click')
+    })
     $publishBox.find('.update').on('click', function () {
       const $update = $(this)
       $update.prop('disabled', true)
@@ -68,8 +77,9 @@
           post_id: jQuery('#post_ID').val(),
           nonce: boxData.nonce,
           subaction: 'publish',
-          publish: $(`#${pluginName}-should-publish`).is(':checked'),
-          text: $(`#${pluginName}-text-to-publish`).val()
+          publish: $(`#${pluginName}-should-publish`).is(':checked') ? 1 : 0,
+          text: $(`#${pluginName}-text-to-publish`).val(),
+          skip_post: $publishBox.find('.update').data('skip-post') ? 1 : 0
         }, function (response) {
           $update.prop('disabled', false)
           $publishBox.find('.spinner').removeClass('is-active')
@@ -80,9 +90,11 @@
           $(`#${pluginName}-message`).hide()
           boxData = response.data
           processUI()
+          $publishBox.find('.update').data('skip-post', false)
         }
       )
     })
+
     $linkBox.find('.update').on('click', function () {
       const $update = $(this)
       $update.prop('disabled', true)

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -213,7 +213,6 @@ class Neznam_Atproto_Share_Logic {
 			$this->log( 'FATAL', $body );
 			return false;
 		}
-		$this->log( 'DEBUG', $body['body'] );
 		return json_decode( $body['body'], true );
 	}
 

--- a/includes/class-neznam-atproto-share.php
+++ b/includes/class-neznam-atproto-share.php
@@ -110,6 +110,11 @@ class Neznam_Atproto_Share {
 		require_once plugin_dir_path( __DIR__ ) . 'admin/class-neznam-atproto-share-admin.php';
 
 		/**
+		 * The class responsible for managing post metaboxes in the admin area.
+		 */
+		require_once plugin_dir_path( __DIR__ ) . 'admin/class-neznam-atproto-share-admin-metabox.php';
+
+		/**
 		 * The class responsible for defining all actions that occur in the public area.
 		 */
 		require_once plugin_dir_path( __DIR__ ) . 'public/class-neznam-atproto-share-public.php';
@@ -147,13 +152,11 @@ class Neznam_Atproto_Share {
 	 */
 	private function define_hooks() {
 
-		$plugin_admin = new Neznam_Atproto_Share_Admin( $this->get_plugin_name(), $this->get_version() );
 		$plugin_share = new Neznam_Atproto_Share_Logic( $this->get_plugin_name(), $this->get_version() );
+		$plugin_admin = new Neznam_Atproto_Share_Admin( $this->get_plugin_name(), $this->get_version(), $plugin_share );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_page' );
-		$this->loader->add_action( 'admin_init', $plugin_admin, 'add_settings' );
-		$this->loader->add_action( 'save_post', $plugin_admin, 'edit_post', 10, 2 );
+		$this->loader->add_action( 'admin_init', $plugin_admin, 'admin_init' );
 		$this->loader->add_action( 'wp_after_insert_post', $plugin_admin, 'publish_post', 10, 2 );
-		$this->loader->add_action( 'add_meta_boxes', $plugin_admin, 'add_meta_box' );
 		$this->loader->add_filter( 'cron_schedules', $plugin_admin, 'cron_schedule' );
 		$this->loader->add_filter( 'plugin_action_links_' . $this->plugin_name . '/' . $this->plugin_name . '.php', $plugin_admin, 'settings_link' );
 

--- a/public/class-neznam-atproto-share-public.php
+++ b/public/class-neznam-atproto-share-public.php
@@ -176,6 +176,17 @@ class Neznam_Atproto_Share_Public {
 				'in_footer' => true,
 			)
 		);
+		$translation_array = array(
+			'no_replies'   => __( 'No replies.', 'neznam-atproto-share ' ),
+			'post_reply'   => __( 'Post a reply on BlueSky.', 'neznam-atproto-share ' ),
+			'show_replies' => __( 'Show replies', 'neznam-atproto-share ' ),
+			'remaining'    => __( 'remaining', 'neznam-atproto-share ' ),
+		);
+		wp_localize_script(
+			$this->plugin_name . '-comments',
+			'neznam_atproto_share_comments',
+			$translation_array
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR includes updates in 6 main areas, in addition to more localization strings being included:

## Ajax Metabox
Before the `add_meta_box` relied on the complete page's update to have its action taken. This update securely isolates that box to its own AJAX endpoint. Beyond performance reasons, this gives the capability for the box to show error and success messages.

## Disassociating Posts - within metabox
For any post that's already been published on atproto, this gives the ability to remove that association (for situations where the AtProto post may have been deleted).

## Linking Posts - within metabox
For situations where a published post might want to be link to an exist posting of the author, for example if the post predates the plugin installation, posting the AtProto's `record key` will let the blog post be linked.

## Comment Pagination
In the event the Bluesky conversation has a long thread, the page is limited to the first 50 comments showing in the browser, with a link available to load an additional 50 comments at a time.

## Rich Comments
Using more of the data provided by the feed, the `facets` are now securely worked into the comment text.

## Uploads via Local Path
The `upload_blob` method was previously relying on `WP_Filesystem`'s capability to download remote files, which could sometimes fail (e.g., WAF). This update grabs the known local path of the image and uploads that directly.
