### PR TITLE
Direct-post hotfix & comment cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+node_modules

--- a/admin/class-neznam-atproto-share-admin-metabox.php
+++ b/admin/class-neznam-atproto-share-admin-metabox.php
@@ -137,6 +137,7 @@ class Neznam_Atproto_Share_Admin_Metabox {
 			<span class="spinner"></span>
 		</div>
 		<div id="<?php echo esc_html( $this->plugin_name ); ?>-publish-post" style="display: none">
+			<input type="hidden" name="<?php echo esc_html( $this->plugin_name ); ?>-default-nonce" value="<?php echo esc_attr( wp_create_nonce( 'default' ) ); ?>" />
 			<input
 				id="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"
 				name="<?php echo esc_html( $this->plugin_name ); ?>-should-publish"
@@ -231,7 +232,7 @@ class Neznam_Atproto_Share_Admin_Metabox {
 			if ( $skip_post || ! $should_publish || 'publish' !== get_post_status( $post_id ) ) {
 				wp_send_json_success( $this->get_ajax_data( $post_id ) );
 			}
-			$this->plugin_admin->publish_post( $post_id, get_post( $post_id ) );
+			$this->plugin_admin->publish_post( get_post( $post_id ) );
 			$share_info = get_post_meta( $post_id, $this->plugin_name . '-uri', true );
 			if ( ! empty( $share_info ) ) {
 				wp_send_json_success( $this->get_ajax_data( $post_id ) );

--- a/includes/class-neznam-atproto-share.php
+++ b/includes/class-neznam-atproto-share.php
@@ -156,7 +156,7 @@ class Neznam_Atproto_Share {
 		$plugin_admin = new Neznam_Atproto_Share_Admin( $this->get_plugin_name(), $this->get_version(), $plugin_share );
 		$this->loader->add_action( 'admin_menu', $plugin_admin, 'add_page' );
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'admin_init' );
-		$this->loader->add_action( 'wp_after_insert_post', $plugin_admin, 'publish_post', 10, 2 );
+		$this->loader->add_action( 'save_post', $plugin_admin, 'save_post', 10, 2 );
 		$this->loader->add_filter( 'cron_schedules', $plugin_admin, 'cron_schedule' );
 		$this->loader->add_filter( 'plugin_action_links_' . $this->plugin_name . '/' . $this->plugin_name . '.php', $plugin_admin, 'settings_link' );
 

--- a/public/css/neznam-atproto-share-comments.css
+++ b/public/css/neznam-atproto-share-comments.css
@@ -1,65 +1,88 @@
+#comments.neznam-atproto-share-comments div.comment-overview {
+	border-top: 1px solid var(--wp--preset--color--border-dark, "#3f3856");
+	border-bottom: 1px solid var(--wp--preset--color--border-light, "#e6e7fb");
+	padding: 10px 0;
+	margin-bottom: 10px;
+}
+
 #comments.neznam-atproto-share-comments ol {
-    list-style: none;
+	list-style: none;
 }
 
 #comments.neznam-atproto-share-comments ol.comment-list {
-    padding-inline-start: 0;
+	padding-inline-start: 0;
 }
 
 #comments.neznam-atproto-share-comments ol article {
-    display: flex;
-    gap: 5px;
-    flex-direction: column;
-    margin-bottom: 30px;
-    font-size: 90%;
+	display: flex;
+	gap: 5px;
+	flex-direction: column;
+	margin-bottom: 30px;
+	font-size: 90%;
 }
-#comments.neznam-atproto-share-comments ol .comment-meta {
-    display: flex;
-    flex-direction: row;
-    margin: 0;
-}
-#comments.neznam-atproto-share-comments ol .comment-meta .comment-avatar {
-    flex: 0 0 auto;
-    width: 50px;
-}
-#comments.neznam-atproto-share-comments ol .comment-meta .comment-avatar img, #comments.neznam-atproto-share-comments ol .comment-meta .comment-avatar svg {
-    height: 42px;
-    width: 42px;
-    clip-path: circle();
-}
-#comments.neznam-atproto-share-comments ol .comment-metadata {
-    display: flex;
-    flex-direction: column;
-}
-#comments.neznam-atproto-share-comments ol .comment-metadata .comment-author {
-    margin: 0;
-    font-size: 18px;
-    font-weight: bold;
-}
-#comments.neznam-atproto-share-comments ol .comment-metadata .comment-time {
-    margin: 0;
-    font-size: 16px;
-}
-#comments.neznam-atproto-share-comments ol .comment-metadata time {
-    margin: 0;
-}
-#comments.neznam-atproto-share-comments a {
-    text-decoration: none;
-}  
-#comments.neznam-atproto-share-comments a:hover, #comments.neznam-atproto-share-comments a:active {
-    text-decoration: underline;
-}  
 
-#comments.neznam-atproto-share-comments .comment-reply-link, #comments.neznam-atproto-share-comments .comment-repost-link, #comments.neznam-atproto-share-comments .comment-like-link, #comments.neznam-atproto-share-comments .comment-quote-link {
-    display: inline-block;
-    background-position: left 0 top 0;
-    background-repeat: no-repeat;
-    padding: 0 0 0 25px;
-    line-height: 25px;
-    font-size: 15px;
-    border: 0;
-    font-weight: normal;
+#comments.neznam-atproto-share-comments ol .comment-meta {
+	display: flex;
+	flex-direction: row;
+	margin: 0;
 }
+
+#comments.neznam-atproto-share-comments ol .comment-meta .comment-avatar {
+	flex: 0 0 auto;
+	width: 50px;
+}
+
+#comments.neznam-atproto-share-comments ol .comment-meta .comment-avatar img,
+#comments.neznam-atproto-share-comments ol .comment-meta .comment-avatar svg {
+	height: 42px;
+	width: 42px;
+	clip-path: circle();
+}
+
+#comments.neznam-atproto-share-comments ol .comment-metadata {
+	display: flex;
+	flex-direction: column;
+}
+
+#comments.neznam-atproto-share-comments ol .comment-metadata .comment-author {
+	margin: 0;
+	font-size: 18px;
+	font-weight: 700;
+}
+
+#comments.neznam-atproto-share-comments ol .comment-metadata .comment-time {
+	margin: 0;
+	font-size: 16px;
+}
+
+#comments.neznam-atproto-share-comments ol .comment-metadata time {
+	margin: 0;
+}
+
+#comments.neznam-atproto-share-comments a {
+	text-decoration: none;
+}
+
+#comments.neznam-atproto-share-comments a:hover,
+#comments.neznam-atproto-share-comments a:active {
+	text-decoration: underline;
+}
+
+#comments.neznam-atproto-share-comments .comment-reply-link,
+#comments.neznam-atproto-share-comments .comment-repost-link,
+#comments.neznam-atproto-share-comments .comment-like-link,
+#comments.neznam-atproto-share-comments .comment-quote-link {
+	display: inline-block;
+	background-position: left 0 top 0;
+	background-repeat: no-repeat;
+	padding: 0 0 0 25px;
+	line-height: 25px;
+	font-size: 15px;
+	border: 0;
+	font-weight: 400;
+}
+
+/* stylelint-disable */
 #comments.neznam-atproto-share-comments .comment-reply-link {
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="21" height="21" viewBox="0 0 21 21" style="stroke:currentColor"><path fill="none" stroke-linecap="round" stroke-linejoin="round" d="M11 16.517c4.418 0 8-3.284 8-7.017S15.418 3 11 3S3 6.026 3 9.759c0 1.457.546 2.807 1.475 3.91L3.5 18.25l3.916-2.447a9.2 9.2 0 0 0 3.584.714" /></svg>');
 }
@@ -72,3 +95,4 @@
 #comments.neznam-atproto-share-comments .comment-quote-link {
     background-image: url('data:image/svg+xml;utf8,<svg height="21" viewBox="0 0 21 21" width="21" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" transform="translate(4 3)"><path d="m12.5 12.5v-10c0-1.1045695-.8954305-2-2-2h-8c-1.1045695 0-2 .8954305-2 2v10c0 1.1045695.8954305 2 2 2h8c1.1045695 0 2-.8954305 2-2z"/><path d="m3.5 5.5h5"/><path d="m3.5 7.5h6"/><path d="m3.5 9.5h3"/></g></svg>');
 }
+/* stylelint-enable */

--- a/public/js/neznam-atproto-share-comments.js
+++ b/public/js/neznam-atproto-share-comments.js
@@ -1,6 +1,6 @@
 /* global jQuery, neznam_atproto_share_comments */
-(function ($) {
-  /*
+( function ( $ ) {
+	/*
   MIT License
 
   Copyright (c) 2024 Nicholas Sideras
@@ -24,240 +24,333 @@
   SOFTWARE.
   */
 
-  // Public domain image from https://commons.wikimedia.org/wiki/File:Default_pfp.svg
-  const defaultAvatar = `<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewbox="0 0 340 340">
-  <path fill="#DDD" d="m169,.5a169,169 0 1,0 2,0zm0,86a76,76 0 1 1-2,0zM57,287q27-35 67-35h92q40,0 67,35a164,164 0 0,1-226,0"/></svg>`
+	// Public domain image from https://commons.wikimedia.org/wiki/File:Default_pfp.svg
+	const defaultAvatar = `<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewbox="0 0 340 340">
+  <path fill="#DDD" d="m169,.5a169,169 0 1,0 2,0zm0,86a76,76 0 1 1-2,0zM57,287q27-35 67-35h92q40,0 67,35a164,164 0 0,1-226,0"/></svg>`;
 
-  const rootElement = document.querySelector('#comments.neznam-atproto-share-comments')
-  if (!rootElement || !rootElement.dataset.uri) return
-  const atProto = rootElement.dataset.uri
-  const commentTemplate = document.querySelector('#neznam-atproto-comment-template')
-  if (!commentTemplate) {
-    console.warn('Unable to load comment template. Aborting comment rendering')
-    return
-  }
-  const commentOverview = document.querySelector('#neznam-atproto-comment-overview')
-  const pageLimit = 50
-  const shownComments = 0
-  const commentCutoff = shownComments + pageLimit
+	const rootElement = document.querySelector(
+		'#comments.neznam-atproto-share-comments'
+	);
+	if ( ! rootElement || ! rootElement.dataset.uri ) {
+		return;
+	}
+	const atProto = rootElement.dataset.uri;
+	const commentTemplate = document.querySelector(
+		'#neznam-atproto-comment-template'
+	);
+	if ( ! commentTemplate ) {
+		/* eslint-disable no-console */
+		console.warn(
+			'Unable to load comment template. Aborting comment rendering'
+		);
+		/* eslint-enable no-console */
+		return;
+	}
+	const commentOverview = document.querySelector(
+		'#neznam-atproto-comment-overview'
+	);
+	const pageLimit = 50;
+	const shownComments = 0;
+	const commentCutoff = shownComments + pageLimit;
 
-  fetch(
-    'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=' + atProto
-  )
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`HTTP error, status = ${response.status}`)
-      }
-      return response.json()
-    })
-    .then((data) => {
-      if (
-        typeof data.thread.replies !== 'undefined' &&
-        data.thread.replies.length > 0
-      ) {
-        const overview = createElementFromHTML(renderOverview(data.thread.post))
-        rootElement.replaceChildren(overview)
-        rootElement.style.position = 'relative'
-        const list = renderComments(data.thread, 'comment-list', 1, 1)
-        rootElement.appendChild(list.ol)
+	fetch(
+		'https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=' +
+			atProto
+	)
+		.then( ( response ) => {
+			if ( ! response.ok ) {
+				throw new Error( `HTTP error, status = ${ response.status }` );
+			}
+			return response.json();
+		} )
+		.then( ( data ) => {
+			if (
+				typeof data.thread.replies !== 'undefined' &&
+				data.thread.replies.length > 0
+			) {
+				const overview = createElementFromHTML(
+					renderOverview( data.thread.post )
+				);
+				rootElement.replaceChildren( overview );
+				rootElement.style.position = 'relative';
+				const list = renderComments(
+					data.thread,
+					'comment-list',
+					1,
+					1
+				);
+				rootElement.appendChild( list.ol );
 
-        // Due to hidden and blocked comments, the post.replyCount does not include an accurate count. Display based on number rendered.
-        $(list.ol).find('.neznam-atproto-show-more-comments').each(function () {
-          const currentPoint = parseInt($(this).data('starting'), 10)
-          if (currentPoint + pageLimit < list.count) {
-            $(this).text(neznam_atproto_share_comments.show_replies + ` ${currentPoint} - ${currentPoint + pageLimit} (${list.count - currentPoint} ${neznam_atproto_share_comments.remaining})`)
-          } else {
-            $(this).text(neznam_atproto_share_comments.show_replies + ` ${currentPoint} - ${list.count}`)
-          }
-        })
-        const someReplies = document.createElement('p')
-        someReplies.innerHTML = '<hr><a href="' + ToBskyUrl(rootElement.dataset.uri) + '" rel="ugc external nofollow" target="_blank">' + neznam_atproto_share_comments.post_reply + '</a>'
-        rootElement.append(someReplies)
-      } else {
-        const noReplies = document.createElement('em')
-        noReplies.innerHTML = neznam_atproto_share_comments.no_replies + '<a href="' + ToBskyUrl(rootElement.dataset.uri) + '" rel="ugc external nofollow" target="_blank">' + neznam_atproto_share_comments.post_reply + '</a>'
-        rootElement.replaceChildren(noReplies)
-      }
-    })
-    .catch((error) => {
-      console.warn(error)
-      const p = document.createElement('p')
-      p.appendChild(document.createTextNode(`Error: ${error.message}`))
-      document.body.appendChild(p, rootElement)
-    })
+				// Due to hidden and blocked comments, the post.replyCount does not include an accurate count. Display based on number rendered.
+				$( list.ol )
+					.find( '.neznam-atproto-show-more-comments' )
+					.each( function () {
+						const currentPoint = parseInt(
+							$( this ).data( 'starting' ),
+							10
+						);
+						if ( currentPoint + pageLimit < list.count ) {
+							$( this ).text(
+								neznam_atproto_share_comments.show_replies + // eslint-disable-line camelcase
+									` ${ currentPoint } - ${
+										currentPoint + pageLimit
+									} (${ list.count - currentPoint } ${
+										neznam_atproto_share_comments.remaining // eslint-disable-line camelcase
+									})`
+							);
+						} else {
+							$( this ).text(
+								neznam_atproto_share_comments.show_replies + // eslint-disable-line camelcase
+									` ${ currentPoint } - ${ list.count }`
+							);
+						}
+					} );
+				const someReplies = document.createElement( 'p' );
+				someReplies.innerHTML =
+					'<hr><a href="' +
+					ToBskyUrl( rootElement.dataset.uri ) +
+					'" rel="ugc external nofollow" target="_blank">' +
+					neznam_atproto_share_comments.post_reply + // eslint-disable-line camelcase
+					'</a>';
+				rootElement.append( someReplies );
+			} else {
+				const noReplies = document.createElement( 'div' );
+				noReplies.innerHTML =
+					'<div class="comment-overview"><em>' +
+					neznam_atproto_share_comments.no_replies + // eslint-disable-line camelcase
+					'</em></div><a href="' +
+					ToBskyUrl( rootElement.dataset.uri ) +
+					'" rel="ugc external nofollow" target="_blank">' +
+					neznam_atproto_share_comments.post_reply + // eslint-disable-line camelcase
+					'</a>';
+				rootElement.replaceChildren( noReplies );
+			}
+		} )
+		.catch( ( error ) => {
+			/* eslint-disable no-console */
+			console.warn( error );
+			/* eslint-enable no-console */
+			const p = document.createElement( 'p' );
+			p.appendChild(
+				document.createTextNode( `Error: ${ error.message }` )
+			);
+			document.body.appendChild( p, rootElement );
+		} );
 
-  function ToBskyUrl (uri) {
-    const splitUri = uri.split('/')
-    if (splitUri[0] === 'at:') {
-      return 'https://bsky.app/profile/' + splitUri[2] + '/post/' + splitUri[4]
-    } else {
-      return uri
-    }
-  }
+	function ToBskyUrl( uri ) {
+		const splitUri = uri.split( '/' );
+		if ( splitUri[ 0 ] === 'at:' ) {
+			return (
+				'https://bsky.app/profile/' +
+				splitUri[ 2 ] +
+				'/post/' +
+				splitUri[ 4 ]
+			);
+		}
+		return uri;
+	}
 
-  function renderComments (thread, classname, depth, count) {
-    if (thread.replies && thread.replies.length > 0) {
-      const ol = document.createElement('ol')
-      ol.className = classname
-      for (const comment of thread.replies) {
-        const renderedString = renderComment(comment)
-        if (!renderedString) continue
-        const htmlContent = createElementFromHTML(renderedString)
-        const li = document.createElement('li')
-        const swap = count % 2 ? 'odd' : 'even'
-        li.className = `comment depth-${depth} ${swap} thread-${swap}`
-        li.id = `neznam-atproto-comment-${count}`
-        if (count > commentCutoff) {
-          li.style.display = 'none'
-        }
-        li.appendChild(htmlContent)
-        if (count % pageLimit === 0) {
-          showMoreLink(li, count + 1)
-        }
-        count++
+	function renderComments( thread, classname, depth, count ) {
+		if ( thread.replies && thread.replies.length > 0 ) {
+			const ol = document.createElement( 'ol' );
+			ol.className = classname;
+			for ( const comment of thread.replies ) {
+				const renderedString = renderComment( comment );
+				if ( ! renderedString ) {
+					continue;
+				}
+				const htmlContent = createElementFromHTML( renderedString );
+				const li = document.createElement( 'li' );
+				const swap = count % 2 ? 'odd' : 'even';
+				li.className = `comment depth-${ depth } ${ swap } thread-${ swap }`;
+				li.id = `neznam-atproto-comment-${ count }`;
+				if ( count > commentCutoff ) {
+					li.style.display = 'none';
+				}
+				li.appendChild( htmlContent );
+				if ( count % pageLimit === 0 ) {
+					showMoreLink( li, count + 1 );
+				}
+				count++;
 
-        if (comment.replies && comment.replies.length > 0) {
-          const comments = renderComments(comment, 'children', depth + 1, count)
-          if (comments) {
-            li.appendChild(comments.ol)
-            count = comments.count
-          }
-        }
-        ol.appendChild(li)
-      }
-      return {
-        ol,
-        count
-      }
-    }
-    return false
-  }
+				if ( comment.replies && comment.replies.length > 0 ) {
+					const comments = renderComments(
+						comment,
+						'children',
+						depth + 1,
+						count
+					);
+					if ( comments ) {
+						li.appendChild( comments.ol );
+						count = comments.count;
+					}
+				}
+				ol.appendChild( li );
+			}
+			return {
+				ol,
+				count,
+			};
+		}
+		return false;
+	}
 
-  function showMoreLink (li, count) {
-    const div = document.createElement('div')
-    div.style.height = '2rem'
+	function showMoreLink( li, count ) {
+		const div = document.createElement( 'div' );
+		div.style.height = '2rem';
 
-    const p = document.createElement('p')
-    p.style.position = 'absolute'
-    p.style.left = 0
-    p.innerHTML = `<a href="#" class="neznam-atproto-show-more-comments" data-starting="${count}"></a>`
-    $('a', p).on('click', function (e) {
-      e.preventDefault()
-      $(this).parent().parent().hide()
-      const starting = $(this).data('starting')
-      for (let i = starting; i < pageLimit + starting; i++) {
-        const comment = document.getElementById(`neznam-atproto-comment-${i}`)
-        if (comment) {
-          comment.style.display = 'block'
-        } else {
-          break
-        }
-      }
-    })
-    div.appendChild(p)
-    li.appendChild(div)
-  }
+		const p = document.createElement( 'p' );
+		p.style.position = 'absolute';
+		p.style.left = 0;
+		p.innerHTML = `<a href="#" class="neznam-atproto-show-more-comments" data-starting="${ count }"></a>`;
+		$( 'a', p ).on( 'click', function ( e ) {
+			e.preventDefault();
+			$( this ).parent().parent().hide();
+			const starting = $( this ).data( 'starting' );
+			for ( let i = starting; i < pageLimit + starting; i++ ) {
+				const comment = document.getElementById(
+					`neznam-atproto-comment-${ i }`
+				);
+				if ( comment ) {
+					comment.style.display = 'block';
+				} else {
+					break;
+				}
+			}
+		} );
+		div.appendChild( p );
+		li.appendChild( div );
+	}
 
-  // https://stackoverflow.com/a/494348
-  function createElementFromHTML (htmlString) {
-    const div = document.createElement('div')
-    div.innerHTML = htmlString.trim()
-    return div.firstChild
-  }
+	// https://stackoverflow.com/a/494348
+	function createElementFromHTML( htmlString ) {
+		const div = document.createElement( 'div' );
+		div.innerHTML = htmlString.trim();
+		return div.firstChild;
+	}
 
-  function sanitizeAttr (text) {
-    return text.replaceAll('"', '&quot;')
-  }
+	function sanitizeAttr( text ) {
+		return text.replaceAll( '"', '&quot;' );
+	}
 
-  function utf8Slice (str, start, end) {
-    const encoder = new TextEncoder()
-    const encoded = encoder.encode(str)
-    return new TextDecoder('utf-8').decode(encoded.slice(start, end))
-  }
+	function utf8Slice( str, start, end ) {
+		const encoder = new TextEncoder();
+		const encoded = encoder.encode( str );
+		return new TextDecoder( 'utf-8' ).decode( encoded.slice( start, end ) );
+	}
 
-  function escapeHTML (str) {
-    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;')
-  }
+	function escapeHTML( str ) {
+		return str.replace( /&/g, '&amp;' ).replace( /</g, '&lt;' );
+	}
 
-  function embedFacets (text, facets) {
-    if (!facets || facets.length === 0) return escapeHTML(text)
-    const randomChar = (Math.random() + 1).toString(36)
+	function embedFacets( text, facets ) {
+		if ( ! facets || facets.length === 0 ) {
+			return escapeHTML( text );
+		}
+		const randomChar = ( Math.random() + 1 ).toString( 36 );
 
-    // Embed facets by iterating from the end to avoid index conflicts
-    for (let i = facets.length - 1; i >= 0; i--) {
-      const facet = facets[i]
-      const { byteStart, byteEnd } = facet.index
-      let replacement = utf8Slice(text, byteStart, byteEnd)
-      if (facet.features[0].$type === 'app.bsky.richtext.facet#link') {
-        replacement = `${randomChar}a style="color:red" href="${facet.features[0].uri}" rel="ugc external nofollow" target="_blank">${replacement}${randomChar}/a>`
-      } else if (facet.features[0].$type === 'app.bsky.richtext.facet#mention') {
-        replacement = `${randomChar}a style="color:red" href="https://bsky.app/profile/${facet.features[0].did}" rel="ugc external nofollow" target="_blank">${replacement}${randomChar}/a>`
-      } else if (facet.features[0].$type === 'app.bsky.richtext.facet#tag') {
-        replacement = `${randomChar}a style="color:red" href="https://bsky.app/hashtag/${facet.features[0].tag}" rel="ugc external nofollow" target="_blank">${replacement}${randomChar}/a>`
-      } else {
-        console.log(`Unrecognized facet type: ${facet.features[0].$type}`)
-        continue
-      }
+		// Embed facets by iterating from the end to avoid index conflicts
+		for ( let i = facets.length - 1; i >= 0; i-- ) {
+			const facet = facets[ i ];
+			const { byteStart, byteEnd } = facet.index;
+			let replacement = utf8Slice( text, byteStart, byteEnd );
+			if (
+				facet.features[ 0 ].$type === 'app.bsky.richtext.facet#link'
+			) {
+				replacement = `${ randomChar }a style="color:red" href="${ facet.features[ 0 ].uri }" rel="ugc external nofollow" target="_blank">${ replacement }${ randomChar }/a>`;
+			} else if (
+				facet.features[ 0 ].$type === 'app.bsky.richtext.facet#mention'
+			) {
+				replacement = `${ randomChar }a style="color:red" href="https://bsky.app/profile/${ facet.features[ 0 ].did }" rel="ugc external nofollow" target="_blank">${ replacement }${ randomChar }/a>`;
+			} else if (
+				facet.features[ 0 ].$type === 'app.bsky.richtext.facet#tag'
+			) {
+				replacement = `${ randomChar }a style="color:red" href="https://bsky.app/hashtag/${ facet.features[ 0 ].tag }" rel="ugc external nofollow" target="_blank">${ replacement }${ randomChar }/a>`;
+			} else {
+				/* eslint-disable no-console */
+				console.log(
+					`Unrecognized facet type: ${ facet.features[ 0 ].$type }`
+				);
+				/* eslint-enable no-console */
+				continue;
+			}
 
-      text =
-        utf8Slice(text, 0, byteStart) +
-        replacement +
-        utf8Slice(text, byteEnd)
-    }
+			text =
+				utf8Slice( text, 0, byteStart ) +
+				replacement +
+				utf8Slice( text, byteEnd );
+		}
 
-    return escapeHTML(text).replaceAll(randomChar, '<')
-  }
+		return escapeHTML( text ).replaceAll( randomChar, '<' );
+	}
 
-  function renderComment (comment) {
-    if (!comment.post.record || !comment.post.record.text || !comment.post.record.createdAt || !comment.post.author || !comment.post.author.handle || !comment.post.uri) {
-      return false
-    }
+	function renderComment( comment ) {
+		if (
+			! comment.post.record ||
+			! comment.post.record.text ||
+			! comment.post.record.createdAt ||
+			! comment.post.author ||
+			! comment.post.author.handle ||
+			! comment.post.uri
+		) {
+			return false;
+		}
 
-    const replyDate = new Date(comment.post.record.createdAt)
-    const authorName = comment.post.author.displayName ? comment.post.author.displayName : '@' + comment.post.author.handle
-    const replyCount = comment.post.replyCount ?? '0'
-    const repostCount = comment.post.repostCount ?? '0'
-    const likeCount = comment.post.likeCount ?? '0'
-    let authorImage = defaultAvatar
-    if (comment.post.author.avatar) {
-      authorImage = `<img src="${comment.post.author.avatar}" loading="lazy" alt="Profile picture of ${sanitizeAttr(authorName)}">`
-    }
+		const replyDate = new Date( comment.post.record.createdAt );
+		const authorName = comment.post.author.displayName
+			? comment.post.author.displayName
+			: '@' + comment.post.author.handle;
+		const replyCount = comment.post.replyCount ?? '0';
+		const repostCount = comment.post.repostCount ?? '0';
+		const likeCount = comment.post.likeCount ?? '0';
+		let authorImage = defaultAvatar;
+		if ( comment.post.author.avatar ) {
+			authorImage = `<img src="${
+				comment.post.author.avatar
+			}" loading="lazy" alt="Profile picture of ${ sanitizeAttr(
+				authorName
+			) }">`;
+		}
 
-    let commentHTML = commentTemplate.innerHTML
-    const replacements = {
-      '##AUTHOR_IMAGE##': authorImage,
-      '##AUTHOR_PROFILE_URL##': `https://bsky.app/profile/${comment.post.author.handle}`,
-      '##AUTHOR_NAME##': escapeHTML(authorName),
-      '##POST_DATE_ISO##': replyDate.toISOString(),
-      '##POST_DATA_HUMAN##': replyDate.toLocaleString(),
-      '##POST_URL##': ToBskyUrl(comment.post.uri),
-      '##POST_TEXT##': embedFacets(comment.post.record.text, comment.post.record.facets),
-      '##REPLY_COUNT##': replyCount,
-      '##REPOST_COUNT##': repostCount,
-      '##LIKE_COUNT##': likeCount
-    }
-    for (const key of Object.keys(replacements)) {
-      commentHTML = commentHTML.replaceAll(key, replacements[key])
-    }
-    return commentHTML
-  }
+		let commentHTML = commentTemplate.innerHTML;
+		const replacements = {
+			'##AUTHOR_IMAGE##': authorImage,
+			'##AUTHOR_PROFILE_URL##': `https://bsky.app/profile/${ comment.post.author.handle }`,
+			'##AUTHOR_NAME##': escapeHTML( authorName ),
+			'##POST_DATE_ISO##': replyDate.toISOString(),
+			'##POST_DATA_HUMAN##': replyDate.toLocaleString(),
+			'##POST_URL##': ToBskyUrl( comment.post.uri ),
+			'##POST_TEXT##': embedFacets(
+				comment.post.record.text,
+				comment.post.record.facets
+			),
+			'##REPLY_COUNT##': replyCount,
+			'##REPOST_COUNT##': repostCount,
+			'##LIKE_COUNT##': likeCount,
+		};
+		for ( const key of Object.keys( replacements ) ) {
+			commentHTML = commentHTML.replaceAll( key, replacements[ key ] );
+		}
+		return commentHTML;
+	}
 
-  function renderOverview (post) {
-    const replyCount = post.replyCount ?? '0'
-    const repostCount = post.repostCount ?? '0'
-    const likeCount = post.likeCount ?? '0'
-    const quoteCount = post.quoteCount ?? '0'
+	function renderOverview( post ) {
+		const replyCount = post.replyCount ?? '0';
+		const repostCount = post.repostCount ?? '0';
+		const likeCount = post.likeCount ?? '0';
+		const quoteCount = post.quoteCount ?? '0';
 
-    let commentHTML = commentOverview.innerHTML
-    const replacements = {
-      '##TOTAL_LIKES##': likeCount,
-      '##TOTAL_QUOTES##': quoteCount,
-      '##TOTAL_REPLIES##': replyCount,
-      '##TOTAL_REPOSTS##': repostCount
-    }
-    for (const key of Object.keys(replacements)) {
-      commentHTML = commentHTML.replaceAll(key, replacements[key])
-    }
-    return commentHTML
-  }
-})(jQuery)
+		let commentHTML = commentOverview.innerHTML;
+		const replacements = {
+			'##POST_URL##': ToBskyUrl( post.uri ),
+			'##TOTAL_LIKES##': likeCount,
+			'##TOTAL_QUOTES##': quoteCount,
+			'##TOTAL_REPLIES##': replyCount,
+			'##TOTAL_REPOSTS##': repostCount,
+		};
+		for ( const key of Object.keys( replacements ) ) {
+			commentHTML = commentHTML.replaceAll( key, replacements[ key ] );
+		}
+		return commentHTML;
+	}
+} )( jQuery );


### PR DESCRIPTION
* Handles when a post is published without interacting with the metabox, taking the form's data in case the AJAX wasn't called (also moving the action from `wp_after_insert_post` to `save_post` to be more consistent with the behavior of other plugins)
* Minor cosmetic spacing issues fixed in the comment
* Fixed the comment overview not applying the proper link to the main Bluesky post
* Running the .js and .css through `wp-scripts lint-js` and `wp-scripts lint-style`, respectively

@mbanusic I'm still working on an expanded README, but since there's an open conversation I wanted to get the ball rolling on a 2.1.1