### PR TITLE
Add the option to include tags

### DIFF
--- a/admin/class-neznam-atproto-share-admin.php
+++ b/admin/class-neznam-atproto-share-admin.php
@@ -170,6 +170,16 @@ class Neznam_Atproto_Share_Admin {
 				'default'           => '0',
 			)
 		);
+
+		register_setting(
+			'neznam-atproto-share',
+			$this->plugin_name . '-tags',
+			array(
+				'sanitize_callback' => 'sanitize_text_field',
+				'default'           => '0',
+			)
+		);
+        
 		register_setting(
 			'neznam-atproto-share',
 			$this->plugin_name . '-post-format',
@@ -338,6 +348,19 @@ class Neznam_Atproto_Share_Admin {
 			'neznam-atproto-share',
 			$this->plugin_name . '-section'
 		);
+
+		add_settings_field(
+			$this->plugin_name . '-tags',
+			'Include tags',
+			function () {
+				?>
+				<input type="checkbox" name="<?php echo esc_html( $this->plugin_name ); ?>-tags" value="1" <?php checked( 1, get_option( $this->plugin_name . '-tags' ), true ); ?> />
+				<small><?php esc_html_e( 'Include WordPress tags in the ATProto post', 'neznam-atproto-share' ); ?></small>
+				<?php
+			},
+			'neznam-atproto-share',
+			$this->plugin_name . '-section'
+		);        
 
 		add_settings_field(
 			$this->plugin_name . '-debug-level',

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -278,9 +278,9 @@ class Neznam_Atproto_Share_Logic {
 			}
 		}
         $include_tags = get_option( $this->plugin_name . '-tags' );
-        $post_tags = get_the_tags($post->ID);
 
         if ($post_tags && $include_tags) {
+            $post_tags = get_the_tags($post->ID);
             $tag_string = '';
             foreach ($post_tags as $tag) {
                 $tag_string .= "#" . $tag->name . ' ';

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -279,15 +279,17 @@ class Neznam_Atproto_Share_Logic {
 		}
         $include_tags = get_option( $this->plugin_name . '-tags' );
 
-        if ($post_tags && $include_tags) {
-            $post_tags = get_the_tags($post->ID);
-            $tag_string = '';
-            foreach ($post_tags as $tag) {
-                $tag_string .= "#" . $tag->name . ' ';
+        if ( $include_tags ) {
+            $post_tags = get_the_tags( $post->ID );
+            if ( $post_tags && !is_wp_error( $post_tags ) ) {
+                $tag_string = '';
+                foreach ( $post_tags as $tag ) {
+                    $tag_string .= "#" . $tag->name . ' ';
+                }
+                $tag_string = trim( $tag_string );
+                $post_text = $post_text . "\n" . $tag_string;
             }
-            $tag_string = trim($tag_string);
-            $post_text = $post_text . "\n" . $tag_string;
-        }
+        }   
 
 		$locale = str_replace( '_', '-', get_locale() );
 

--- a/includes/class-neznam-atproto-share-logic.php
+++ b/includes/class-neznam-atproto-share-logic.php
@@ -277,6 +277,17 @@ class Neznam_Atproto_Share_Logic {
 				$post_text = $post->post_title;
 			}
 		}
+        $include_tags = get_option( $this->plugin_name . '-tags' );
+        $post_tags = get_the_tags($post->ID);
+
+        if ($post_tags && $include_tags) {
+            $tag_string = '';
+            foreach ($post_tags as $tag) {
+                $tag_string .= "#" . $tag->name . ' ';
+            }
+            $tag_string = trim($tag_string);
+            $post_text = $post_text . "\n" . $tag_string;
+        }
 
 		$locale = str_replace( '_', '-', get_locale() );
 


### PR DESCRIPTION
This adds a simple preferences toggle to include the WordPress post's tags in the ATProto post